### PR TITLE
docs(SKILL): 补全 §9 骨架的引擎↔容器对应，避免 Chart.js 套 div 报错

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -201,6 +201,8 @@ Lieflat Charts 是一套遵循 Agent Skills 格式的单色数据可视化 skill
 <title>Mono — {图名}</title>
 <!-- 需要 ECharts 时： -->
 <script src="https://cdn.jsdelivr.net/npm/echarts@6/dist/echarts.min.js"></script>
+<!-- 需要 Chart.js 时（G1 / G3）： -->
+<!-- <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="{MONO.FONT.link}" rel="stylesheet">
 <style>/* 内联 MONO.CARD_CSS */</style>
@@ -210,7 +212,11 @@ Lieflat Charts 是一套遵循 Agent Skills 格式的单色数据可视化 skill
   <div class="card"><!-- 或 card dark / card wide -->
     <h2>{结论式标题}</h2>
     <div class="sub">{说明} · {图例} · {时间范围}</div>
-    <div class="ch" id="ch"></div><!-- SVG 图型改用 <svg id="ch" viewBox="0 0 400 320"> -->
+    <!-- 图容器按引擎三选一： -->
+    <div class="ch" id="ch"></div><!-- ECharts -->
+    <!-- 手写 SVG： <svg id="ch" viewBox="0 0 400 320"></svg> -->
+    <!-- Chart.js（G1/G3）： <div class="wrap"><canvas id="ch"></canvas></div>，配 .wrap{position:relative;height:320px} -->
+    <!-- ⚠️ Chart.js 必须挂 <canvas>，套 <div class="ch"> 会报 can't acquire context -->
     <div class="src">{图型名} · {系列} · {数据来源}</div>
   </div>
 </div>


### PR DESCRIPTION
## 背景

拿真实数据（联合国 2024 世界人口前八）分别按 F5 Tick Rows 和 G3 Chunky Bars 各跑了一遍，发现照 `SKILL.md` §9 的单文件骨架生成 Glance 图（G1/G3）时会**必踩一个坑**。

## 问题

§9 骨架里图容器只给了一种写法，注释也只提醒了 SVG：

```html
<div class="ch" id="ch"></div><!-- SVG 图型改用 <svg id="ch" viewBox="0 0 400 320"> -->
```

但仓库有三种引擎，容器要求不同（见 `templates/glance-gallery.html`）：

| 引擎 | 正确容器 | gallery 实例 |
|---|---|---|
| ECharts | `<div class="ch" id="ch"></div>` | `#rose`、`#forest` … |
| 手写 SVG | `<svg id="ch" viewBox="0 0 400 320"></svg>` | Lupi / Basics 全系 |
| **Chart.js** | `<div class="wrap"><canvas id="ch"></canvas></div>` | `#c1`、`#c3`（G1/G3） |

按现骨架给 Chart.js 图型套 `<div class="ch">`，浏览器直接报：
`Failed to create chart: can't acquire context from the given item`
——Chart.js 必须拿到 `<canvas>` 的 2D context。此外 §9 的 `<head>` 只给了 ECharts 的 CDN，用 G1/G3 还需引 `chart.js`。

## 改动

只动 §9 骨架的注释（无任何逻辑/模板改动）：
- CDN 段补一行 Chart.js（G1/G3）的引入提示；
- 图容器注释扩成「按引擎三选一」，并对 Chart.js 标注 `<canvas>` 与 `can't acquire context` 的坑。

## 复现

按现骨架给 G3 套 `<div class="ch">` → 控制台报 `can't acquire context`；换 `<div class="wrap"><canvas>` 后正常。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
