### PR TITLE
Fix prefers-reduced-motion support in Glance templates

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -42,6 +42,12 @@ const treemapTemplates = [
   'templates/color/basics-palm.html',
   'templates/color/basics-wire.html',
 ];
+const glanceMotionTemplates = [
+  'templates/glance-gallery.html',
+  'templates/color/glance-porcelain.html',
+  'templates/color/glance-palm.html',
+  'templates/color/glance-wire.html',
+];
 
 function walk(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -88,6 +94,52 @@ function collectPresetChannels(value, channels = new Set()) {
   return channels;
 }
 
+function checkGlanceMotion(file, source) {
+  const fail = message => failures.push(`${file} ${message}`);
+  const script = [...source.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi)]
+    .map(match => match[1])
+    .join('\n');
+
+  if (!/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)[\s\S]*?animation\s*:\s*none/.test(source)) {
+    fail('缺少 CSS reduced-motion 降级');
+  }
+  if (!/matchMedia\s*\(\s*['"]\(prefers-reduced-motion\s*:\s*reduce\)['"]\s*\)/.test(script)) {
+    fail('缺少 JS reduced-motion 检测');
+  }
+  if (!/reduceMotion[\s\S]*?animation\s*:\s*false[\s\S]*?new\s+Chart/.test(script)) {
+    fail('Chart.js 未关闭 reduced-motion 动画');
+  }
+  if (!/getInstanceByDom[\s\S]*?reduceMotion[\s\S]*?animation\s*:\s*false/.test(script)) {
+    fail('ECharts 未关闭 reduced-motion 动画');
+  }
+
+  for (const match of script.matchAll(/setInterval\s*\(/g)) {
+    const context = script.slice(Math.max(0, match.index - 180), match.index);
+    if (!/if\s*\(\s*!\s*reduceMotion\s*\)/.test(context)) {
+      fail('存在未受 reduced-motion 保护的 interval');
+    }
+  }
+  for (const match of script.matchAll(/requestAnimationFrame\s*\(/g)) {
+    const context = script.slice(Math.max(0, match.index - 900), match.index);
+    if (!/if\s*\(\s*reduceMotion\s*\)[\s\S]*?return\s*;/.test(context)) {
+      fail('存在未受 reduced-motion 保护的 RAF');
+    }
+  }
+
+  if (!/VIEWS\.length\s*-\s*1/.test(script) || !/VIEWS\[\s*vi\s*\]\.opt/.test(script)) {
+    fail('morph 未在 reduced-motion 下选择稳定最终视图');
+  }
+  if (!/YEARS\.length\s*-\s*1/.test(script) || !/vals\[\s*step\s*\]/.test(script)) {
+    fail('bar race 未在 reduced-motion 下选择稳定最终状态');
+  }
+  if (!/obsReveal\(\s*['"]stream['"][\s\S]*?draw\(\);[\s\S]*?if\s*\(\s*!\s*reduceMotion\s*\)/.test(script)) {
+    fail('stream 未在 reduced-motion 下先绘制稳定快照');
+  }
+  if (!/if\s*\(\s*reduceMotion\s*\)[\s\S]*?TOTAL\s*\/\s*1000/.test(script)) {
+    fail('counter 未在 reduced-motion 下写入最终 KPI');
+  }
+}
+
 for (const file of required) {
   if (!fs.existsSync(path.join(root, file))) failures.push(`缺少发布文件：${file}`);
 }
@@ -99,6 +151,15 @@ for (const file of treemapTemplates) {
   if (!source.includes('id="treemap"')) failures.push(`${file} 缺少 F13 treemap 容器`);
   if (!source.includes("type:'treemap'")) failures.push(`${file} 缺少 F13 treemap 渲染代码`);
   if (!source.includes('F1–F13')) failures.push(`${file} 的 Basics 编号未更新为 F1–F13`);
+}
+
+for (const file of glanceMotionTemplates) {
+  const full = path.join(root, file);
+  if (!fs.existsSync(full)) {
+    failures.push(`缺少 Glance reduced-motion 模板：${file}`);
+    continue;
+  }
+  checkGlanceMotion(file, fs.readFileSync(full, 'utf8'));
 }
 
 const catalogSource = fs.readFileSync(path.join(root, 'catalog.md'), 'utf8');

--- a/templates/color/glance-palm.html
+++ b/templates/color/glance-palm.html
@@ -25,6 +25,7 @@
   svg text{font-family:'Inter',sans-serif}
   .pop{transform-box:fill-box;transform-origin:center;animation:pop .5s cubic-bezier(.2,.7,.3,1.3) both}
   @keyframes pop{from{transform:scale(0)}to{transform:none}}
+  @media (prefers-reduced-motion: reduce){.pop{animation:none!important}}
 
   .pagehead{max-width:1400px;margin:0 auto 26px;padding:0 4px}
   .pagehead h1{font-size:22px;letter-spacing:-.02em;font-weight:800}
@@ -214,6 +215,7 @@ const rankOf=a=>{const r=[...a].map((v,i)=>[v,i]).sort((x,y)=>y[0]-x[0]).map(d=>
 const tipLight={backgroundColor:INK,borderWidth:0,textStyle:{color:PAPER,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const tipDark={backgroundColor:PAPER,borderWidth:0,textStyle:{color:INK,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const rnd=(i,k)=>((i*73856093)^(k*19349663))%1000/1000; // deterministic
+const reduceMotion=matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 // ── unified reveal: every chart waits to be scrolled into view; click replays.
 //    fn charts manage their own timers via keep(); they're cleared on replay.
@@ -231,12 +233,14 @@ const obsReveal=(id,fn)=>{
 const keep=(id,t)=>{(timers[id]=timers[id]||[]).push(t)};
 const eReveal=(id,opt)=>obsReveal(id,el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
-  g.clear();g.setOption(opt);
+  g.clear();g.setOption(reduceMotion?{...opt,animation:false,animationDuration:0,animationDurationUpdate:0}:opt);
 });
 const cjs={};
 const cReveal=(id,mkCfg)=>obsReveal(id,el=>{
   cjs[id]?.destroy();
-  cjs[id]=new Chart(el,mkCfg());
+  const cfg=mkCfg();
+  if(reduceMotion)cfg.options={...cfg.options,animation:false};
+  cjs[id]=new Chart(el,cfg);
 });
 
 Chart.defaults.color=MUTED;
@@ -548,13 +552,13 @@ const VIEWS=[
     }],
   }},
 ];
-const base={animationDurationUpdate:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
+const base={animation:!reduceMotion,animationDurationUpdate:reduceMotion?0:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
 obsReveal('morph',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let vi=0;
-  g.setOption({...base,...VIEWS[0].opt});
-  keep('morph',setInterval(()=>{
+  let vi=reduceMotion?VIEWS.length-1:0;
+  g.setOption({...base,...VIEWS[vi].opt});
+  if(!reduceMotion)keep('morph',setInterval(()=>{
     vi=(vi+1)%VIEWS.length;
     g.setOption({...base,...VIEWS[vi].opt},{replaceMerge:['xAxis','yAxis','series']});
   },3000));
@@ -811,25 +815,25 @@ for(let y=1;y<YEARS.length;y++)
 obsReveal('race',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let step=0;
+  let step=reduceMotion?YEARS.length-1:0;
   const frame=()=>{
     const row=vals[step];
     const rank=[...row].map((v,i)=>[v,i]).sort((a,b)=>b[0]-a[0]).map(d=>d[1]);
     g.setOption({
-      animationDuration:0,animationDurationUpdate:950,animationEasingUpdate:'linear',
+      animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:950,animationEasingUpdate:'linear',
       tooltip:{...tipLight,valueFormatter:v=>'$'+Math.round(v)+'K'},
       grid:{left:64,right:64,top:8,bottom:8},
       xAxis:{type:'value',max:'dataMax',
         splitLine:{show:false},axisLine:{show:false},axisTick:{show:false},axisLabel:{show:false}},
       yAxis:{type:'category',data:P,inverse:true,max:7,
-        animationDuration:300,animationDurationUpdate:300,
+        animationDuration:reduceMotion?0:300,animationDurationUpdate:reduceMotion?0:300,
         axisLine:{show:false},axisTick:{show:false},
         axisLabel:{color:LAB,fontFamily:'Inter',fontSize:9.5,fontWeight:600}},
       series:[{
         type:'bar',realtimeSort:true,barCategoryGap:'32%',
         data:row.map((v,i)=>({value:v,
           itemStyle:{color:rampAt(rank.indexOf(i),8),borderRadius:99}})),
-        label:{show:true,position:'right',valueAnimation:true,
+        label:{show:true,position:'right',valueAnimation:!reduceMotion,
           fontFamily:'Inter',fontSize:12,fontWeight:800,color:INK,
           formatter:p=>'$'+Math.round(p.value)+'K'},
       }],
@@ -839,7 +843,7 @@ obsReveal('race',el=>{
     step=(step+1)%YEARS.length;
   };
   frame();
-  keep('race',setInterval(frame,1150));
+  if(!reduceMotion)keep('race',setInterval(frame,1150));
 });
 })();
 
@@ -853,7 +857,7 @@ obsReveal('stream',el=>{
   const data=[];
   for(;t<WIN;t++){v=Math.max(30,v+(rnd(t+1,7)-.48)*9);data.push(Math.round(v))}
   const draw=()=>g.setOption({
-    animation:true,animationDuration:0,animationDurationUpdate:260,animationEasingUpdate:'linear',
+    animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:260,animationEasingUpdate:'linear',
     tooltip:{...tipLight,valueFormatter:x=>x+'k users'},
     grid:{left:14,right:58,top:44,bottom:20},
     xAxis:{type:'category',data:data.map((_,i)=>t-WIN+i),boundaryGap:false,
@@ -873,7 +877,7 @@ obsReveal('stream',el=>{
     ]}],
   });
   draw();
-  keep('stream',setInterval(()=>{
+  if(!reduceMotion)keep('stream',setInterval(()=>{
     v=Math.max(30,Math.min(125,v+(rnd(t+1,7)-.48)*9));
     data.push(Math.round(v));data.shift();t++;
     draw();
@@ -894,7 +898,7 @@ obsReveal('stroke',el=>{
   g.clear();
   gen++;const my=gen;
   g.setOption({
-    animationDuration:DUR,animationEasing:'cubicOut',
+    animation:!reduceMotion,animationDuration:reduceMotion?0:DUR,animationEasing:'cubicOut',
     tooltip:{show:false},
     grid:{left:14,right:20,top:64,bottom:24},
     xAxis:{type:'category',data:days,boundaryGap:false,
@@ -909,6 +913,13 @@ obsReveal('stroke',el=>{
         colorStops:[{offset:0,color:alpha(DATA,.14)},{offset:1,color:alpha(DATA,0)}]}},
     }],
   });
+  if(reduceMotion){
+    g.setOption({graphic:[{id:'kpi',type:'group',left:16,top:8,children:[
+      {type:'text',style:{text:'$'+(TOTAL/1000).toFixed(2)+'M',font:'800 32px Inter',fill:INK}},
+      {type:'text',style:{text:'ARR · H1 2026',y:38,font:'600 10px Inter',fill:'#8F8E88'}}
+    ]}]});
+    return;
+  }
   const t0=performance.now();
   const tick=()=>{
     if(my!==gen)return;

--- a/templates/color/glance-porcelain.html
+++ b/templates/color/glance-porcelain.html
@@ -25,6 +25,7 @@
   svg text{font-family:'Inter',sans-serif}
   .pop{transform-box:fill-box;transform-origin:center;animation:pop .5s cubic-bezier(.2,.7,.3,1.3) both}
   @keyframes pop{from{transform:scale(0)}to{transform:none}}
+  @media (prefers-reduced-motion: reduce){.pop{animation:none!important}}
 
   .pagehead{max-width:1400px;margin:0 auto 26px;padding:0 4px}
   .pagehead h1{font-size:22px;letter-spacing:-.02em;font-weight:800}
@@ -214,6 +215,7 @@ const rankOf=a=>{const r=[...a].map((v,i)=>[v,i]).sort((x,y)=>y[0]-x[0]).map(d=>
 const tipLight={backgroundColor:INK,borderWidth:0,textStyle:{color:PAPER,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const tipDark={backgroundColor:PAPER,borderWidth:0,textStyle:{color:INK,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const rnd=(i,k)=>((i*73856093)^(k*19349663))%1000/1000; // deterministic
+const reduceMotion=matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 // ── unified reveal: every chart waits to be scrolled into view; click replays.
 //    fn charts manage their own timers via keep(); they're cleared on replay.
@@ -231,12 +233,14 @@ const obsReveal=(id,fn)=>{
 const keep=(id,t)=>{(timers[id]=timers[id]||[]).push(t)};
 const eReveal=(id,opt)=>obsReveal(id,el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
-  g.clear();g.setOption(opt);
+  g.clear();g.setOption(reduceMotion?{...opt,animation:false,animationDuration:0,animationDurationUpdate:0}:opt);
 });
 const cjs={};
 const cReveal=(id,mkCfg)=>obsReveal(id,el=>{
   cjs[id]?.destroy();
-  cjs[id]=new Chart(el,mkCfg());
+  const cfg=mkCfg();
+  if(reduceMotion)cfg.options={...cfg.options,animation:false};
+  cjs[id]=new Chart(el,cfg);
 });
 
 Chart.defaults.color=MUTED;
@@ -548,13 +552,13 @@ const VIEWS=[
     }],
   }},
 ];
-const base={animationDurationUpdate:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
+const base={animation:!reduceMotion,animationDurationUpdate:reduceMotion?0:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
 obsReveal('morph',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let vi=0;
-  g.setOption({...base,...VIEWS[0].opt});
-  keep('morph',setInterval(()=>{
+  let vi=reduceMotion?VIEWS.length-1:0;
+  g.setOption({...base,...VIEWS[vi].opt});
+  if(!reduceMotion)keep('morph',setInterval(()=>{
     vi=(vi+1)%VIEWS.length;
     g.setOption({...base,...VIEWS[vi].opt},{replaceMerge:['xAxis','yAxis','series']});
   },3000));
@@ -811,25 +815,25 @@ for(let y=1;y<YEARS.length;y++)
 obsReveal('race',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let step=0;
+  let step=reduceMotion?YEARS.length-1:0;
   const frame=()=>{
     const row=vals[step];
     const rank=[...row].map((v,i)=>[v,i]).sort((a,b)=>b[0]-a[0]).map(d=>d[1]);
     g.setOption({
-      animationDuration:0,animationDurationUpdate:950,animationEasingUpdate:'linear',
+      animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:950,animationEasingUpdate:'linear',
       tooltip:{...tipLight,valueFormatter:v=>'$'+Math.round(v)+'K'},
       grid:{left:64,right:64,top:8,bottom:8},
       xAxis:{type:'value',max:'dataMax',
         splitLine:{show:false},axisLine:{show:false},axisTick:{show:false},axisLabel:{show:false}},
       yAxis:{type:'category',data:P,inverse:true,max:7,
-        animationDuration:300,animationDurationUpdate:300,
+        animationDuration:reduceMotion?0:300,animationDurationUpdate:reduceMotion?0:300,
         axisLine:{show:false},axisTick:{show:false},
         axisLabel:{color:LAB,fontFamily:'Inter',fontSize:9.5,fontWeight:600}},
       series:[{
         type:'bar',realtimeSort:true,barCategoryGap:'32%',
         data:row.map((v,i)=>({value:v,
           itemStyle:{color:rampAt(rank.indexOf(i),8),borderRadius:99}})),
-        label:{show:true,position:'right',valueAnimation:true,
+        label:{show:true,position:'right',valueAnimation:!reduceMotion,
           fontFamily:'Inter',fontSize:12,fontWeight:800,color:INK,
           formatter:p=>'$'+Math.round(p.value)+'K'},
       }],
@@ -839,7 +843,7 @@ obsReveal('race',el=>{
     step=(step+1)%YEARS.length;
   };
   frame();
-  keep('race',setInterval(frame,1150));
+  if(!reduceMotion)keep('race',setInterval(frame,1150));
 });
 })();
 
@@ -853,7 +857,7 @@ obsReveal('stream',el=>{
   const data=[];
   for(;t<WIN;t++){v=Math.max(30,v+(rnd(t+1,7)-.48)*9);data.push(Math.round(v))}
   const draw=()=>g.setOption({
-    animation:true,animationDuration:0,animationDurationUpdate:260,animationEasingUpdate:'linear',
+    animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:260,animationEasingUpdate:'linear',
     tooltip:{...tipLight,valueFormatter:x=>x+'k users'},
     grid:{left:14,right:58,top:44,bottom:20},
     xAxis:{type:'category',data:data.map((_,i)=>t-WIN+i),boundaryGap:false,
@@ -873,7 +877,7 @@ obsReveal('stream',el=>{
     ]}],
   });
   draw();
-  keep('stream',setInterval(()=>{
+  if(!reduceMotion)keep('stream',setInterval(()=>{
     v=Math.max(30,Math.min(125,v+(rnd(t+1,7)-.48)*9));
     data.push(Math.round(v));data.shift();t++;
     draw();
@@ -894,7 +898,7 @@ obsReveal('stroke',el=>{
   g.clear();
   gen++;const my=gen;
   g.setOption({
-    animationDuration:DUR,animationEasing:'cubicOut',
+    animation:!reduceMotion,animationDuration:reduceMotion?0:DUR,animationEasing:'cubicOut',
     tooltip:{show:false},
     grid:{left:14,right:20,top:64,bottom:24},
     xAxis:{type:'category',data:days,boundaryGap:false,
@@ -909,6 +913,13 @@ obsReveal('stroke',el=>{
         colorStops:[{offset:0,color:alpha(DATA,.14)},{offset:1,color:alpha(DATA,0)}]}},
     }],
   });
+  if(reduceMotion){
+    g.setOption({graphic:[{id:'kpi',type:'group',left:16,top:8,children:[
+      {type:'text',style:{text:'$'+(TOTAL/1000).toFixed(2)+'M',font:'800 32px Inter',fill:INK}},
+      {type:'text',style:{text:'ARR · H1 2026',y:38,font:'600 10px Inter',fill:'#8F8E88'}}
+    ]}]});
+    return;
+  }
   const t0=performance.now();
   const tick=()=>{
     if(my!==gen)return;

--- a/templates/color/glance-wire.html
+++ b/templates/color/glance-wire.html
@@ -25,6 +25,7 @@
   svg text{font-family:'Inter',sans-serif}
   .pop{transform-box:fill-box;transform-origin:center;animation:pop .5s cubic-bezier(.2,.7,.3,1.3) both}
   @keyframes pop{from{transform:scale(0)}to{transform:none}}
+  @media (prefers-reduced-motion: reduce){.pop{animation:none!important}}
 
   .pagehead{max-width:1400px;margin:0 auto 26px;padding:0 4px}
   .pagehead h1{font-size:22px;letter-spacing:-.02em;font-weight:800}
@@ -214,6 +215,7 @@ const rankOf=a=>{const r=[...a].map((v,i)=>[v,i]).sort((x,y)=>y[0]-x[0]).map(d=>
 const tipLight={backgroundColor:INK,borderWidth:0,textStyle:{color:PAPER,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const tipDark={backgroundColor:PAPER,borderWidth:0,textStyle:{color:INK,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const rnd=(i,k)=>((i*73856093)^(k*19349663))%1000/1000; // deterministic
+const reduceMotion=matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 // ── unified reveal: every chart waits to be scrolled into view; click replays.
 //    fn charts manage their own timers via keep(); they're cleared on replay.
@@ -231,12 +233,14 @@ const obsReveal=(id,fn)=>{
 const keep=(id,t)=>{(timers[id]=timers[id]||[]).push(t)};
 const eReveal=(id,opt)=>obsReveal(id,el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
-  g.clear();g.setOption(opt);
+  g.clear();g.setOption(reduceMotion?{...opt,animation:false,animationDuration:0,animationDurationUpdate:0}:opt);
 });
 const cjs={};
 const cReveal=(id,mkCfg)=>obsReveal(id,el=>{
   cjs[id]?.destroy();
-  cjs[id]=new Chart(el,mkCfg());
+  const cfg=mkCfg();
+  if(reduceMotion)cfg.options={...cfg.options,animation:false};
+  cjs[id]=new Chart(el,cfg);
 });
 
 Chart.defaults.color=MUTED;
@@ -548,13 +552,13 @@ const VIEWS=[
     }],
   }},
 ];
-const base={animationDurationUpdate:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
+const base={animation:!reduceMotion,animationDurationUpdate:reduceMotion?0:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
 obsReveal('morph',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let vi=0;
-  g.setOption({...base,...VIEWS[0].opt});
-  keep('morph',setInterval(()=>{
+  let vi=reduceMotion?VIEWS.length-1:0;
+  g.setOption({...base,...VIEWS[vi].opt});
+  if(!reduceMotion)keep('morph',setInterval(()=>{
     vi=(vi+1)%VIEWS.length;
     g.setOption({...base,...VIEWS[vi].opt},{replaceMerge:['xAxis','yAxis','series']});
   },3000));
@@ -811,25 +815,25 @@ for(let y=1;y<YEARS.length;y++)
 obsReveal('race',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let step=0;
+  let step=reduceMotion?YEARS.length-1:0;
   const frame=()=>{
     const row=vals[step];
     const rank=[...row].map((v,i)=>[v,i]).sort((a,b)=>b[0]-a[0]).map(d=>d[1]);
     g.setOption({
-      animationDuration:0,animationDurationUpdate:950,animationEasingUpdate:'linear',
+      animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:950,animationEasingUpdate:'linear',
       tooltip:{...tipLight,valueFormatter:v=>'$'+Math.round(v)+'K'},
       grid:{left:64,right:64,top:8,bottom:8},
       xAxis:{type:'value',max:'dataMax',
         splitLine:{show:false},axisLine:{show:false},axisTick:{show:false},axisLabel:{show:false}},
       yAxis:{type:'category',data:P,inverse:true,max:7,
-        animationDuration:300,animationDurationUpdate:300,
+        animationDuration:reduceMotion?0:300,animationDurationUpdate:reduceMotion?0:300,
         axisLine:{show:false},axisTick:{show:false},
         axisLabel:{color:LAB,fontFamily:'Inter',fontSize:9.5,fontWeight:600}},
       series:[{
         type:'bar',realtimeSort:true,barCategoryGap:'32%',
         data:row.map((v,i)=>({value:v,
           itemStyle:{color:rampAt(rank.indexOf(i),8),borderRadius:99}})),
-        label:{show:true,position:'right',valueAnimation:true,
+        label:{show:true,position:'right',valueAnimation:!reduceMotion,
           fontFamily:'Inter',fontSize:12,fontWeight:800,color:INK,
           formatter:p=>'$'+Math.round(p.value)+'K'},
       }],
@@ -839,7 +843,7 @@ obsReveal('race',el=>{
     step=(step+1)%YEARS.length;
   };
   frame();
-  keep('race',setInterval(frame,1150));
+  if(!reduceMotion)keep('race',setInterval(frame,1150));
 });
 })();
 
@@ -853,7 +857,7 @@ obsReveal('stream',el=>{
   const data=[];
   for(;t<WIN;t++){v=Math.max(30,v+(rnd(t+1,7)-.48)*9);data.push(Math.round(v))}
   const draw=()=>g.setOption({
-    animation:true,animationDuration:0,animationDurationUpdate:260,animationEasingUpdate:'linear',
+    animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:260,animationEasingUpdate:'linear',
     tooltip:{...tipLight,valueFormatter:x=>x+'k users'},
     grid:{left:14,right:58,top:44,bottom:20},
     xAxis:{type:'category',data:data.map((_,i)=>t-WIN+i),boundaryGap:false,
@@ -873,7 +877,7 @@ obsReveal('stream',el=>{
     ]}],
   });
   draw();
-  keep('stream',setInterval(()=>{
+  if(!reduceMotion)keep('stream',setInterval(()=>{
     v=Math.max(30,Math.min(125,v+(rnd(t+1,7)-.48)*9));
     data.push(Math.round(v));data.shift();t++;
     draw();
@@ -894,7 +898,7 @@ obsReveal('stroke',el=>{
   g.clear();
   gen++;const my=gen;
   g.setOption({
-    animationDuration:DUR,animationEasing:'cubicOut',
+    animation:!reduceMotion,animationDuration:reduceMotion?0:DUR,animationEasing:'cubicOut',
     tooltip:{show:false},
     grid:{left:14,right:20,top:64,bottom:24},
     xAxis:{type:'category',data:days,boundaryGap:false,
@@ -909,6 +913,13 @@ obsReveal('stroke',el=>{
         colorStops:[{offset:0,color:alpha(DATA,.14)},{offset:1,color:alpha(DATA,0)}]}},
     }],
   });
+  if(reduceMotion){
+    g.setOption({graphic:[{id:'kpi',type:'group',left:16,top:8,children:[
+      {type:'text',style:{text:'$'+(TOTAL/1000).toFixed(2)+'M',font:'800 32px Inter',fill:INK}},
+      {type:'text',style:{text:'ARR · H1 2026',y:38,font:'600 10px Inter',fill:'#8F8E88'}}
+    ]}]});
+    return;
+  }
   const t0=performance.now();
   const tick=()=>{
     if(my!==gen)return;

--- a/templates/glance-gallery.html
+++ b/templates/glance-gallery.html
@@ -25,6 +25,7 @@
   svg text{font-family:'Inter',sans-serif}
   .pop{transform-box:fill-box;transform-origin:center;animation:pop .5s cubic-bezier(.2,.7,.3,1.3) both}
   @keyframes pop{from{transform:scale(0)}to{transform:none}}
+  @media (prefers-reduced-motion: reduce){.pop{animation:none!important}}
 
   .pagehead{max-width:1400px;margin:0 auto 26px;padding:0 4px}
   .pagehead h1{font-size:22px;letter-spacing:-.02em;font-weight:800}
@@ -189,6 +190,7 @@ const LAD=['#1C1C1A','#4A4944','#8F8E88','#B0AFA9','#D8D7D1'];
 const tipLight={backgroundColor:INK,borderWidth:0,textStyle:{color:PAPER,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const tipDark={backgroundColor:PAPER,borderWidth:0,textStyle:{color:INK,fontFamily:'Inter',fontSize:12},padding:[10,14]};
 const rnd=(i,k)=>((i*73856093)^(k*19349663))%1000/1000; // deterministic
+const reduceMotion=matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 // ── unified reveal: every chart waits to be scrolled into view; click replays.
 //    fn charts manage their own timers via keep(); they're cleared on replay.
@@ -206,12 +208,14 @@ const obsReveal=(id,fn)=>{
 const keep=(id,t)=>{(timers[id]=timers[id]||[]).push(t)};
 const eReveal=(id,opt)=>obsReveal(id,el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
-  g.clear();g.setOption(opt);
+  g.clear();g.setOption(reduceMotion?{...opt,animation:false,animationDuration:0,animationDurationUpdate:0}:opt);
 });
 const cjs={};
 const cReveal=(id,mkCfg)=>obsReveal(id,el=>{
   cjs[id]?.destroy();
-  cjs[id]=new Chart(el,mkCfg());
+  const cfg=mkCfg();
+  if(reduceMotion)cfg.options={...cfg.options,animation:false};
+  cjs[id]=new Chart(el,cfg);
 });
 
 Chart.defaults.color=MUTED;
@@ -514,13 +518,13 @@ const VIEWS=[
     }],
   }},
 ];
-const base={animationDurationUpdate:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
+const base={animation:!reduceMotion,animationDurationUpdate:reduceMotion?0:1100,animationEasingUpdate:'cubicInOut',tooltip:{...tipLight}};
 obsReveal('morph',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let vi=0;
-  g.setOption({...base,...VIEWS[0].opt});
-  keep('morph',setInterval(()=>{
+  let vi=reduceMotion?VIEWS.length-1:0;
+  g.setOption({...base,...VIEWS[vi].opt});
+  if(!reduceMotion)keep('morph',setInterval(()=>{
     vi=(vi+1)%VIEWS.length;
     g.setOption({...base,...VIEWS[vi].opt},{replaceMerge:['xAxis','yAxis','series']});
   },3000));
@@ -775,25 +779,25 @@ for(let y=1;y<YEARS.length;y++)
 obsReveal('race',el=>{
   const g=echarts.getInstanceByDom(el)||echarts.init(el);
   g.clear();
-  let step=0;
+  let step=reduceMotion?YEARS.length-1:0;
   const frame=()=>{
     const row=vals[step];
     const rank=[...row].map((v,i)=>[v,i]).sort((a,b)=>b[0]-a[0]).map(d=>d[1]);
     g.setOption({
-      animationDuration:0,animationDurationUpdate:950,animationEasingUpdate:'linear',
+      animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:950,animationEasingUpdate:'linear',
       tooltip:{...tipLight,valueFormatter:v=>'$'+Math.round(v)+'K'},
       grid:{left:64,right:64,top:8,bottom:8},
       xAxis:{type:'value',max:'dataMax',
         splitLine:{show:false},axisLine:{show:false},axisTick:{show:false},axisLabel:{show:false}},
       yAxis:{type:'category',data:P,inverse:true,max:7,
-        animationDuration:300,animationDurationUpdate:300,
+        animationDuration:reduceMotion?0:300,animationDurationUpdate:reduceMotion?0:300,
         axisLine:{show:false},axisTick:{show:false},
         axisLabel:{color:'#6A6963',fontFamily:'Inter',fontSize:9.5,fontWeight:600}},
       series:[{
         type:'bar',realtimeSort:true,barCategoryGap:'32%',
         data:row.map((v,i)=>({value:v,
           itemStyle:{color:L[Math.min(5,rank.indexOf(i))],borderRadius:99}})),
-        label:{show:true,position:'right',valueAnimation:true,
+        label:{show:true,position:'right',valueAnimation:!reduceMotion,
           fontFamily:'Inter',fontSize:12,fontWeight:800,color:INK,
           formatter:p=>'$'+Math.round(p.value)+'K'},
       }],
@@ -803,7 +807,7 @@ obsReveal('race',el=>{
     step=(step+1)%YEARS.length;
   };
   frame();
-  keep('race',setInterval(frame,1150));
+  if(!reduceMotion)keep('race',setInterval(frame,1150));
 });
 })();
 
@@ -817,7 +821,7 @@ obsReveal('stream',el=>{
   const data=[];
   for(;t<WIN;t++){v=Math.max(30,v+(rnd(t+1,7)-.48)*9);data.push(Math.round(v))}
   const draw=()=>g.setOption({
-    animation:true,animationDuration:0,animationDurationUpdate:260,animationEasingUpdate:'linear',
+    animation:!reduceMotion,animationDuration:0,animationDurationUpdate:reduceMotion?0:260,animationEasingUpdate:'linear',
     tooltip:{...tipLight,valueFormatter:x=>x+'k users'},
     grid:{left:14,right:58,top:44,bottom:20},
     xAxis:{type:'category',data:data.map((_,i)=>t-WIN+i),boundaryGap:false,
@@ -837,7 +841,7 @@ obsReveal('stream',el=>{
     ]}],
   });
   draw();
-  keep('stream',setInterval(()=>{
+  if(!reduceMotion)keep('stream',setInterval(()=>{
     v=Math.max(30,Math.min(125,v+(rnd(t+1,7)-.48)*9));
     data.push(Math.round(v));data.shift();t++;
     draw();
@@ -858,7 +862,7 @@ obsReveal('stroke',el=>{
   g.clear();
   gen++;const my=gen;
   g.setOption({
-    animationDuration:DUR,animationEasing:'cubicOut',
+    animation:!reduceMotion,animationDuration:reduceMotion?0:DUR,animationEasing:'cubicOut',
     tooltip:{show:false},
     grid:{left:14,right:20,top:64,bottom:24},
     xAxis:{type:'category',data:days,boundaryGap:false,
@@ -873,6 +877,13 @@ obsReveal('stroke',el=>{
         colorStops:[{offset:0,color:'rgba(28,28,26,.14)'},{offset:1,color:'rgba(28,28,26,0)'}]}},
     }],
   });
+  if(reduceMotion){
+    g.setOption({graphic:[{id:'kpi',type:'group',left:16,top:8,children:[
+      {type:'text',style:{text:'$'+(TOTAL/1000).toFixed(2)+'M',font:'800 32px Inter',fill:INK}},
+      {type:'text',style:{text:'ARR · H1 2026',y:38,font:'600 10px Inter',fill:'#8F8E88'}}
+    ]}]});
+    return;
+  }
   const t0=performance.now();
   const tick=()=>{
     if(my!==gen)return;


### PR DESCRIPTION
## Summary

- Add `prefers-reduced-motion` handling to the Glance gallery and color variants.
- Disable Chart.js and ECharts animations when reduced motion is requested.
- Stop morph, race, and stream intervals in reduced-motion mode.
- Render the final morph/race/counter state without RAF animation.
- Disable `.pop` CSS animation.
- Add a cross-platform reduced-motion contract check to `scripts/validate.mjs`.

## Validation

- All four Glance inline scripts compile successfully.
- Reduced-motion contract passes for all four templates.
- All intervals and RAF paths are guarded.
- `git diff --check` passes.

The repository’s existing 251 validator baseline failures are unchanged and are intentionally outside this PR.
