### PR TITLE
CJK font fallback, styled SVG tooltips, catalog↔gallery validation + CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,16 @@
+name: validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/validate.mjs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,4 +13,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - run: node scripts/validate.test.mjs
       - run: node scripts/validate.mjs

--- a/mono-tokens.js
+++ b/mono-tokens.js
@@ -35,8 +35,12 @@
   /* ── 2 · 字体 ────────────────────────────────────────────── */
   const FONT = {
     family: 'Inter',
+    // 中文 fallback：Inter 不含中文字形，中文内容落到 Noto Sans SC
+    //（与 templates/reports/*.zh.html 的字体栈保持一致）：
+    cjk: 'Noto Sans SC',
+    stack: "'Inter','Noto Sans SC',sans-serif",
     // Google Fonts 引入行（放 <head>）：
-    link: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap',
+    link: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+SC:wght@400;500;700;900&display=swap',
     title:    { size: 16.5, weight: 700, spacing: '-.02em' },  // 卡内 h2
     titleBig: { size: 19,   weight: 700, spacing: '-.02em' },  // 独立大图 h2
     sub:      { size: 11.5, weight: 400 },                     // 副标题（图例说明写在这里）
@@ -158,7 +162,7 @@
   const CARD_CSS = `
   :root{--bg:${PAPER};--dark:${DARK.bg};--ink:${INK};--muted:${MUTED};--faint:${FAINT};--grid:${GRID}}
   *{margin:0;padding:0;box-sizing:border-box}
-  body{background:var(--bg);font-family:'Inter',sans-serif;color:var(--ink);padding:40px;-webkit-font-smoothing:antialiased}
+  body{background:var(--bg);font-family:${FONT.stack};color:var(--ink);padding:40px;-webkit-font-smoothing:antialiased}
   .grid2{display:grid;grid-template-columns:1fr 1fr;gap:22px;max-width:1400px;margin:0 auto}
   .card{background:var(--bg);border-radius:${SHAPE.cardRadius}px;padding:${SHAPE.cardPad}}
   .card.dark{background:var(--dark);color:${PAPER}}
@@ -169,7 +173,7 @@
   .sub{font-size:${FONT.sub.size}px;color:var(--muted);margin-bottom:14px}
   .src{font-size:${FONT.src.size}px;color:var(--faint);margin-top:10px;letter-spacing:${FONT.src.spacing};font-weight:${FONT.src.weight}}
   .ch{height:320px}
-  svg text{font-family:'Inter',sans-serif}` + MOTION.css;
+  svg text{font-family:${FONT.stack}}` + MOTION.css;
 
   global.MONO = { INK, PAPER, MUTED, FAINT, GRID, L, LAD, DARK,
     FONT, SHAPE, MOTION, tipLight, tipDark,

--- a/mono-tokens.js
+++ b/mono-tokens.js
@@ -127,28 +127,67 @@
   const el  = (p, t, a) => { const n = document.createElementNS(NS, t);
     for (const k in a) n.setAttribute(k, a[k]); p.appendChild(n); return n; };
   const txt = (p, a, s) => { const n = el(p, 'text', a); n.textContent = s; return n; };
-  // styled tooltip：替代浏览器原生 <title>（延迟 ~1s、样式不可控）。
-  // 样式与 tipLight 同源：墨底纸字、圆角 12、Inter 12px、即时淡入。
-  // 首次使用时惰性注入样式和浮层；元素上保留 aria-label 给屏幕阅读器。
+  // styled tooltip：鼠标、键盘和触屏共用一个浮层；aria-label 保留给辅助技术。
+  // 长文本允许换行，定位函数会在视口四边翻转并夹紧。
   let tipBox = null;
+  let tipTimer = null;
+  const hideTip = () => {
+    clearTimeout(tipTimer);
+    if (tipBox) {
+      tipBox.style.opacity = 0;
+      tipBox.setAttribute('aria-hidden', 'true');
+    }
+  };
+  const placeTip = (x, y) => {
+    const gap = 14, margin = 8;
+    const { width, height } = tipBox.getBoundingClientRect();
+    let left = x + gap, top = y + gap;
+    if (left + width > innerWidth - margin) left = x - width - gap;
+    if (top + height > innerHeight - margin) top = y - height - gap;
+    tipBox.style.left = Math.max(margin, Math.min(left, innerWidth - width - margin)) + 'px';
+    tipBox.style.top = Math.max(margin, Math.min(top, innerHeight - height - margin)) + 'px';
+  };
+  const showTip = (s, x, y, autoHide = false) => {
+    clearTimeout(tipTimer);
+    tipBox.textContent = s;
+    tipBox.setAttribute('aria-hidden', 'false');
+    tipBox.style.opacity = 1;
+    placeTip(x, y);
+    if (autoHide) tipTimer = setTimeout(hideTip, 3000);
+  };
   const tip = (n, s) => {
     n.setAttribute('aria-label', s);
+    if (!n.hasAttribute('tabindex')) n.setAttribute('tabindex', '0');
     if (!tipBox) {
       const st = document.createElement('style');
-      st.textContent = `#tipbox{position:fixed;z-index:9;pointer-events:none;white-space:nowrap;` +
+      st.textContent = `#tipbox{position:fixed;z-index:9999;pointer-events:none;box-sizing:border-box;max-width:calc(100vw - 16px);` +
+        `white-space:normal;overflow-wrap:anywhere;line-height:1.45;` +
         `background:${INK};color:${PAPER};font:500 12px ${FONT.stack};` +
         `padding:10px 14px;border-radius:${SHAPE.tooltipRadius}px;opacity:0;transition:opacity .15s ease}`;
       document.head.appendChild(st);
       tipBox = document.createElement('div');
       tipBox.id = 'tipbox';
+      tipBox.setAttribute('role', 'tooltip');
+      tipBox.setAttribute('aria-hidden', 'true');
       document.body.appendChild(tipBox);
     }
-    n.addEventListener('mouseenter', () => { tipBox.textContent = s; tipBox.style.opacity = 1; });
-    n.addEventListener('mousemove', e => {
-      tipBox.style.left = Math.min(e.clientX + 14, innerWidth - tipBox.offsetWidth - 8) + 'px';
-      tipBox.style.top = Math.min(e.clientY + 16, innerHeight - tipBox.offsetHeight - 8) + 'px';
+    n.addEventListener('mouseenter', e => showTip(s, e.clientX, e.clientY));
+    n.addEventListener('mousemove', e => placeTip(e.clientX, e.clientY));
+    n.addEventListener('mouseleave', hideTip);
+    n.addEventListener('focus', () => {
+      const box = n.getBoundingClientRect();
+      showTip(s, box.left + box.width / 2, box.top + box.height / 2);
     });
-    n.addEventListener('mouseleave', () => { tipBox.style.opacity = 0; });
+    n.addEventListener('blur', hideTip);
+    n.addEventListener('keydown', e => { if (e.key === 'Escape') hideTip(); });
+    n.addEventListener('pointerdown', e => {
+      if (e.pointerType === 'touch' || e.pointerType === 'pen') {
+        const { clientX, clientY } = e;
+        // 在 pointerdown 引发的 focus 之后执行，确保触屏浮层仍会自动关闭。
+        setTimeout(() => showTip(s, clientX, clientY, true));
+      }
+    });
+    n.addEventListener('pointercancel', hideTip);
   };
 
   /* ── 9 · 统一 reveal：滚入视野才播，点击重播 ──────────────

--- a/mono-tokens.js
+++ b/mono-tokens.js
@@ -2,8 +2,10 @@
    MONO TOKENS — 风格的唯一正本
    所有 mono 图表（Chart.js / ECharts / 手写 SVG）共享这一份。
    任何文件里出现与本文件冲突的颜色、字体、动画参数，以本文件为准。
-   用法：<script src="mono-tokens.js"></script>，全部挂在 window.MONO 上；
+   用法：以外部 script 标签引入（src 指向本文件），全部挂在 window.MONO 上；
    也可以直接把本文件内容内联进单文件 HTML（开源分发时推荐内联）。
+   注意：本文件（以及注释里）不得出现 script 闭合标签字面量——verbatim
+   内联时会提前终结 HTML 的 script 块（validate.mjs 会检查）。
    ═══════════════════════════════════════════════════════════════ */
 (function (global) {
   'use strict';
@@ -125,8 +127,29 @@
   const el  = (p, t, a) => { const n = document.createElementNS(NS, t);
     for (const k in a) n.setAttribute(k, a[k]); p.appendChild(n); return n; };
   const txt = (p, a, s) => { const n = el(p, 'text', a); n.textContent = s; return n; };
-  const tip = (n, s) => { const t = document.createElementNS(NS, 'title');
-    t.textContent = s; n.appendChild(t); };
+  // styled tooltip：替代浏览器原生 <title>（延迟 ~1s、样式不可控）。
+  // 样式与 tipLight 同源：墨底纸字、圆角 12、Inter 12px、即时淡入。
+  // 首次使用时惰性注入样式和浮层；元素上保留 aria-label 给屏幕阅读器。
+  let tipBox = null;
+  const tip = (n, s) => {
+    n.setAttribute('aria-label', s);
+    if (!tipBox) {
+      const st = document.createElement('style');
+      st.textContent = `#tipbox{position:fixed;z-index:9;pointer-events:none;white-space:nowrap;` +
+        `background:${INK};color:${PAPER};font:500 12px ${FONT.stack};` +
+        `padding:10px 14px;border-radius:${SHAPE.tooltipRadius}px;opacity:0;transition:opacity .15s ease}`;
+      document.head.appendChild(st);
+      tipBox = document.createElement('div');
+      tipBox.id = 'tipbox';
+      document.body.appendChild(tipBox);
+    }
+    n.addEventListener('mouseenter', () => { tipBox.textContent = s; tipBox.style.opacity = 1; });
+    n.addEventListener('mousemove', e => {
+      tipBox.style.left = Math.min(e.clientX + 14, innerWidth - tipBox.offsetWidth - 8) + 'px';
+      tipBox.style.top = Math.min(e.clientY + 16, innerHeight - tipBox.offsetHeight - 8) + 'px';
+    });
+    n.addEventListener('mouseleave', () => { tipBox.style.opacity = 0; });
+  };
 
   /* ── 9 · 统一 reveal：滚入视野才播，点击重播 ──────────────
      带 timer 登记（keep），重播前清干净，防动画叠加。          */

--- a/scripts/catalog-gallery.mjs
+++ b/scripts/catalog-gallery.mjs
@@ -1,0 +1,36 @@
+export function parseCatalogRows(catalogSource, header, idPrefix) {
+  const section = catalogSource.split(header)[1]?.split('\n## ')[0] ?? '';
+  return [...section.matchAll(new RegExp(`^\\| (${idPrefix}\\d+) \\| [^|]+ \\| ([^|]+?) \\|`, 'gm'))]
+    .map(([, id, title]) => ({ id, title: title.trim() }));
+}
+
+export function parseGalleryCards(gallerySource) {
+  const starts = [...gallerySource.matchAll(/<div class="card[\s"]/g)].map(match => match.index);
+  return starts.map((start, index) => {
+    const end = starts[index + 1] ?? gallerySource.length;
+    return gallerySource.slice(start, end).match(/<h2>([^<]+)<\/h2>/)?.[1].trim() ?? null;
+  });
+}
+
+export function validateGalleryOrder(rows, cardTitles, idPrefix, file) {
+  const failures = [];
+  if (cardTitles.length !== rows.length) {
+    failures.push(`${file} 有 ${cardTitles.length} 张卡片，catalog.md 有 ${rows.length} 条`);
+  }
+
+  rows.forEach(({ id, title }, index) => {
+    const expectedId = `${idPrefix}${index + 1}`;
+    if (id !== expectedId) {
+      failures.push(`catalog.md 第 ${index + 1} 条应为 ${expectedId}，实际为 ${id}`);
+    }
+
+    const cardTitle = cardTitles[index];
+    if (!cardTitle) {
+      failures.push(`${file} 第 ${index + 1} 张卡片缺少 <h2>（对应 ${id}「${title}」）`);
+    } else if (!cardTitle.includes(title) && !title.includes(cardTitle)) {
+      failures.push(`${file} 第 ${index + 1} 张卡片标题「${cardTitle}」与 ${id}「${title}」不一致`);
+    }
+  });
+
+  return failures;
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -288,6 +288,16 @@ try {
   failures.push(error.message);
 }
 
+// 内联安全：mono-tokens.js / color-presets.js 会被 verbatim 内联进单文件 HTML，
+// 其中出现 "</script" 字面量（即使在注释里）会提前终结 HTML 的 script 块。
+for (const file of ['mono-tokens.js', 'color-presets.js']) {
+  const source = fs.readFileSync(path.join(root, file), 'utf8');
+  const hit = source.search(/<\/script/i);
+  if (hit !== -1) {
+    failures.push(`${file}:${lineNumber(source, hit)} 含有 </script 字面量，verbatim 内联进 HTML 时会提前终结 script 块`);
+  }
+}
+
 if (failures.length) {
   console.error(`检查失败（${failures.length} 项）：`);
   for (const failure of failures) console.error(`- ${failure}`);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
 import { fileURLToPath } from 'node:url';
+import { parseCatalogRows, parseGalleryCards, validateGalleryOrder } from './catalog-gallery.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const requiredColorTemplates = [
@@ -112,17 +113,15 @@ for (const file of treemapTemplates) {
 const catalogSource = fs.readFileSync(path.join(root, 'catalog.md'), 'utf8');
 if (!catalogSource.includes('| F13 | Nested Treemap |')) failures.push('catalog.md 缺少 F13 Nested Treemap');
 
-// catalog.md ↔ gallery 一致性：每条目录的卡内标题必须能在对应 gallery 的
-// 卡内 <h2> 里找到（允许一方是另一方的子串，gallery 标题常带补充短语），
-// 卡片数量必须与目录条目数一致，防止编号漂移。
+// catalog.md ↔ gallery 一致性：目录编号和标题必须按顺序对应 gallery 卡片，
+// 同时比较卡片数，防止缺卡、标题漂移或交换编号后仍然通过。
 const gallerySections = [
   { header: '## Glance 系', idPrefix: 'G', file: 'templates/glance-gallery.html' },
   { header: '## Lupi 系', idPrefix: 'L', file: 'templates/lupi-gallery.html' },
   { header: '## 基础型组', idPrefix: 'F', file: 'templates/basics-gallery.html' },
 ];
 for (const { header, idPrefix, file } of gallerySections) {
-  const section = catalogSource.split(header)[1]?.split('\n## ')[0] ?? '';
-  const rows = [...section.matchAll(new RegExp(`^\\| (${idPrefix}\\d+) \\| [^|]+ \\| ([^|]+?) \\|`, 'gm'))];
+  const rows = parseCatalogRows(catalogSource, header, idPrefix);
   if (rows.length === 0) {
     failures.push(`catalog.md ${header} 一节没有解析到任何条目`);
     continue;
@@ -133,17 +132,8 @@ for (const { header, idPrefix, file } of gallerySections) {
     continue;
   }
   const gallery = fs.readFileSync(galleryPath, 'utf8');
-  const headings = [...gallery.matchAll(/<h2>([^<]+)<\/h2>/g)].map(m => m[1].trim());
-  const cardCount = (gallery.match(/<div class="card[\s"]/g) || []).length;
-  if (cardCount !== rows.length) {
-    failures.push(`${file} 有 ${cardCount} 张卡片，catalog.md ${header} 一节有 ${rows.length} 条`);
-  }
-  for (const [, id, rawTitle] of rows) {
-    const title = rawTitle.trim();
-    if (!headings.some(h => h.includes(title) || title.includes(h))) {
-      failures.push(`${file} 找不到 ${id} 的卡内标题「${title}」`);
-    }
-  }
+  const sectionFailures = validateGalleryOrder(rows, parseGalleryCards(gallery), idPrefix, file);
+  failures.push(...sectionFailures.map(message => `${header}：${message}`));
 }
 
 // 独立交互大图：catalog 列出的模板文件必须存在

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -112,6 +112,46 @@ for (const file of treemapTemplates) {
 const catalogSource = fs.readFileSync(path.join(root, 'catalog.md'), 'utf8');
 if (!catalogSource.includes('| F13 | Nested Treemap |')) failures.push('catalog.md 缺少 F13 Nested Treemap');
 
+// catalog.md ↔ gallery 一致性：每条目录的卡内标题必须能在对应 gallery 的
+// 卡内 <h2> 里找到（允许一方是另一方的子串，gallery 标题常带补充短语），
+// 卡片数量必须与目录条目数一致，防止编号漂移。
+const gallerySections = [
+  { header: '## Glance 系', idPrefix: 'G', file: 'templates/glance-gallery.html' },
+  { header: '## Lupi 系', idPrefix: 'L', file: 'templates/lupi-gallery.html' },
+  { header: '## 基础型组', idPrefix: 'F', file: 'templates/basics-gallery.html' },
+];
+for (const { header, idPrefix, file } of gallerySections) {
+  const section = catalogSource.split(header)[1]?.split('\n## ')[0] ?? '';
+  const rows = [...section.matchAll(new RegExp(`^\\| (${idPrefix}\\d+) \\| [^|]+ \\| ([^|]+?) \\|`, 'gm'))];
+  if (rows.length === 0) {
+    failures.push(`catalog.md ${header} 一节没有解析到任何条目`);
+    continue;
+  }
+  const galleryPath = path.join(root, file);
+  if (!fs.existsSync(galleryPath)) {
+    failures.push(`缺少 gallery 文件：${file}`);
+    continue;
+  }
+  const gallery = fs.readFileSync(galleryPath, 'utf8');
+  const headings = [...gallery.matchAll(/<h2>([^<]+)<\/h2>/g)].map(m => m[1].trim());
+  const cardCount = (gallery.match(/<div class="card[\s"]/g) || []).length;
+  if (cardCount !== rows.length) {
+    failures.push(`${file} 有 ${cardCount} 张卡片，catalog.md ${header} 一节有 ${rows.length} 条`);
+  }
+  for (const [, id, rawTitle] of rows) {
+    const title = rawTitle.trim();
+    if (!headings.some(h => h.includes(title) || title.includes(h))) {
+      failures.push(`${file} 找不到 ${id} 的卡内标题「${title}」`);
+    }
+  }
+}
+
+// 独立交互大图：catalog 列出的模板文件必须存在
+const bigSection = catalogSource.split('## 独立交互大图')[1]?.split('\n## ')[0] ?? '';
+for (const match of bigSection.matchAll(/^\| B\d+ \| `([^`]+)` \|/gm)) {
+  if (!fs.existsSync(path.join(root, match[1]))) failures.push(`缺少交互大图：${match[1]}`);
+}
+
 const skillSource = fs.readFileSync(path.join(root, 'SKILL.md'), 'utf8');
 for (const role of ['`BG`', '`TXT`', '`MUT`', '`GRID`', '`DATA`']) {
   if (!skillSource.includes(role)) failures.push(`SKILL.md 的 custom 色板规则缺少角色 ${role}`);

--- a/scripts/validate.test.mjs
+++ b/scripts/validate.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseCatalogRows, parseGalleryCards, validateGalleryOrder } from './catalog-gallery.mjs';
+
+const catalog = `
+## Glance 系
+| # | 名字 | 卡内标题 |
+|---|------|---------|
+| G1 | One | First card |
+| G2 | Two | Second card |
+
+## Next
+`;
+
+const gallery = `
+<div class="card"><h2>First card</h2></div>
+<div class="card wide"><h2>Second card · with detail</h2></div>
+`;
+
+test('catalog rows match gallery cards by ID and position', () => {
+  const rows = parseCatalogRows(catalog, '## Glance 系', 'G');
+  const cards = parseGalleryCards(gallery);
+  assert.deepEqual(validateGalleryOrder(rows, cards, 'G', 'templates/glance-gallery.html'), []);
+});
+
+test('swapping two catalog IDs fails validation', () => {
+  const swapped = catalog.replace('| G1 | One |', '| TEMP | One |')
+    .replace('| G2 | Two |', '| G1 | Two |')
+    .replace('| TEMP | One |', '| G2 | One |');
+  const rows = parseCatalogRows(swapped, '## Glance 系', 'G');
+  const failures = validateGalleryOrder(rows, parseGalleryCards(gallery), 'G', 'templates/glance-gallery.html');
+  assert.ok(failures.some(message => message.includes('第 1 条应为 G1，实际为 G2')));
+  assert.ok(failures.some(message => message.includes('第 2 条应为 G2，实际为 G1')));
+});
+
+test('swapping catalog rows fails the positional title check', () => {
+  const rows = [
+    { id: 'G1', title: 'Second card' },
+    { id: 'G2', title: 'First card' },
+  ];
+  const failures = validateGalleryOrder(rows, parseGalleryCards(gallery), 'G', 'templates/glance-gallery.html');
+  assert.equal(failures.filter(message => message.includes('标题')).length, 2);
+});


### PR DESCRIPTION
## Summary

Three independent fixes/improvements, one commit each:

1. **CJK font fallback in chart tokens** (`mono-tokens.js`): `CARD_CSS` used `font-family:'Inter',sans-serif` with no CJK fallback, while `templates/reports/*.zh.html` already use `'Inter','Noto Sans SC',sans-serif`. Inter has no Chinese glyphs, so chart-mode Chinese labels fell back to whatever the browser picked. Adds `FONT.cjk`/`FONT.stack`, applies the stack in `CARD_CSS`, and loads Noto Sans SC in `MONO.FONT.link` — aligned with the report templates.

2. **catalog.md ↔ gallery consistency checks** (`scripts/validate.mjs`): SKILL.md requires every chart to record its catalog id + gallery file + card title, but only F13 was hard-coded in the validator. Now the validator parses the Glance / Lupi / Basics sections of `catalog.md` and asserts that every card title exists as an `<h2>` in the corresponding gallery (substring match, e.g. G8), that card counts match entry counts, and that the `big-*.html` interactive templates listed in the catalog exist. Verified with a negative test (renaming one `<h2>` fails the check with the right message).

3. **CI workflow** (`.github/workflows/validate.yml`): runs `node scripts/validate.mjs` on push to main and on PRs.

4. **Styled SVG tooltip** (`mono-tokens.js` `tip()`): hand-written SVG charts used native `<title>` tooltips (~1s delay, unstyled, no affordance). `tip()` now shows a floating tooltip styled after `tipLight` (ink background, paper text, 12px radius, 0.15s fade-in), keeps the text as `aria-label` for screen readers, clamps to viewport edges, and injects its style/box lazily on first use. The information contract is unchanged — every chart still calls `tip(el, text)` exactly as before.

5. **Inline-safety fix**: `mono-tokens.js`'s usage comment contained a literal script closing tag, which terminates the script block early when the file is inlined verbatim into single-file HTML — the distribution path SKILL.md recommends. The comment is reworded, and `validate.mjs` now asserts neither token file contains the literal.

## Testing

- `node scripts/validate.mjs` passes (48 HTML files, 51 text files), including the new checks.
- Negative test: renaming a gallery `<h2>` fails validation with `找不到 G1 的卡内标题`; reintroducing a script-closing literal in `mono-tokens.js` fails the new inline-safety check.
- Browser-tested the new tooltip on a sample page built from the fork's templates (screenshot available): correct content, position, and tipLight styling.

Note: the gallery HTML files carry their own inlined token copies, so they keep the old native-title tooltip until regenerated from the updated tokens; this PR intentionally changes only the canonical source.