### PR TITLE
fix(validate): normalize path separators so validation works on Windows

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -89,7 +89,10 @@ function walk(dir) {
 }
 
 function rel(file) {
-  return path.relative(root, file);
+  // 相对路径要与 'templates/color/...'、'templates/reports/' 等字符串比较，
+  // 分隔符必须是 '/'。Windows 上 path.relative 返回反斜杠，不归一化会让
+  // 颜色检查与 Math.random() 检查的豁免条件全部失效。
+  return path.relative(root, file).split(path.sep).join('/');
 }
 
 function lineNumber(source, index) {


### PR DESCRIPTION
## Problem

On Windows `node scripts/validate.mjs` fails with **722 errors** on a clean checkout of `main`.

`rel()` returns `path.relative(root, file)` verbatim, which on Windows contains backslashes: `templates\color\basics-palm.html`. Three checks compare that string against POSIX-style paths:

- `relative.match(/^templates\/color\/.+-(porcelain|palm|wire)\.html$/)`
- `!relative.startsWith('templates/reports/')`
- `relative === 'scripts/validate.mjs'`

None of them match, so the color templates and the report templates never reach their own branches. They fall through to the mono-only check, and every color literal in them is reported as `检测到明显彩色值`. The `Math.random()` self-exemption for the validator misses for the same reason.

## Fix

One line in `rel()`: normalize the separator to `/`. No behaviour change on Linux or macOS, where `path.sep` is already `/`.

## Verification

Clean checkout of `main`, Node 26, Windows 11:

```
before: 检查失败（722 项）
after:  检查通过：52 个 HTML 文件，56 个文本文件
```

## 中文摘要

Windows 下 `path.relative` 返回反斜杠路径，而 `validate.mjs` 里的豁免条件是按 `templates/color/...`、`templates/reports/` 这样的正斜杠字符串比较的，所以彩色模板和报告模板都落到了「只允许灰阶」那条分支，模板里的每个彩色值都被判为违规——干净仓库直接报 722 项错误。`scripts/validate.mjs` 自身的 `Math.random()` 豁免也因此失效。修正只改 `rel()` 一行：把分隔符统一成 `/`。Linux 与 macOS 行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)